### PR TITLE
Notebook list hover card

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,6 +17,18 @@
   --color-step-11: var(--step-11);
   --color-step-11-5: var(--step-11-5);
   --color-step-12: var(--step-12);
+  --color-tomato-1: var(--tomato-1);
+  --color-tomato-2: var(--tomato-2);
+  --color-tomato-3: var(--tomato-3);
+  --color-tomato-4: var(--tomato-4);
+  --color-tomato-5: var(--tomato-5);
+  --color-tomato-6: var(--tomato-6);
+  --color-tomato-7: var(--tomato-7);
+  --color-tomato-8: var(--tomato-8);
+  --color-tomato-9: var(--tomato-9);
+  --color-tomato-10: var(--tomato-10);
+  --color-tomato-11: var(--tomato-11);
+  --color-tomato-12: var(--tomato-12);
   --font-sans: var(--font-soehne);
   --font-mono: var(--font-geist-mono);
   --color-chart-5: var(--chart-5);
@@ -50,6 +62,20 @@
   --step-11-5: #51504B; /* custom step between 11 and 12 */
   --step-12: #21201c; /* sand12 */
 
+  /* Radix Tomato Light Palette Steps */
+  --tomato-1: #fffcfc; /* tomato1 */
+  --tomato-2: #fff8f7; /* tomato2 */
+  --tomato-3: #feebe7; /* tomato3 */
+  --tomato-4: #ffdcd3; /* tomato4 */
+  --tomato-5: #ffcdc2; /* tomato5 */
+  --tomato-6: #fdbdaf; /* tomato6 */
+  --tomato-7: #f5a898; /* tomato7 */
+  --tomato-8: #ec8e7b; /* tomato8 */
+  --tomato-9: #e54d2e; /* tomato9 */
+  --tomato-10: #dd4425; /* tomato10 */
+  --tomato-11: #d13415; /* tomato11 */
+  --tomato-12: #5c271f; /* tomato12 */
+
   /* Chart colors - kept original, can be mapped to Radix colors if needed */
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
@@ -79,6 +105,20 @@
   --step-11: #b5b3ad; /* sandDark11 */
   --step-11-5: #D0CFCA; /* custom step between 11 and 12 */
   --step-12: #eeeeec; /* sandDark12 */
+
+  /* Radix Tomato Dark Palette Steps */
+  --tomato-1: #181111; /* tomatoDark1 */
+  --tomato-2: #1f1513; /* tomatoDark2 */
+  --tomato-3: #391714; /* tomatoDark3 */
+  --tomato-4: #4e1511; /* tomatoDark4 */
+  --tomato-5: #5e1c16; /* tomatoDark5 */
+  --tomato-6: #6e2920; /* tomatoDark6 */
+  --tomato-7: #853a2d; /* tomatoDark7 */
+  --tomato-8: #ac4d39; /* tomatoDark8 */
+  --tomato-9: #e54d2e; /* tomatoDark9 */
+  --tomato-10: #ec6142; /* tomatoDark10 */
+  --tomato-11: #ff977d; /* tomatoDark11 */
+  --tomato-12: #fbd3cb; /* tomatoDark12 */
 
   /* Chart colors - kept original */
   --chart-1: oklch(0.488 0.243 264.376);

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -681,6 +681,10 @@ export default function HomeView() {
     router.push(`/notebook/${notebookId}`);
   }, [router]);
 
+  const handleDeleteNotebook = useCallback((notebookId: string) => {
+    setRecentNotebooks(prev => prev.filter(notebook => notebook.id !== notebookId));
+  }, []);
+
   // Effect to measure greeting position
   useEffect(() => {
     const measureGreeting = () => {
@@ -966,6 +970,7 @@ export default function HomeView() {
                   <RecentNotebooksList 
                     notebooks={recentNotebooks}
                     onSelectNotebook={handleSelectRecentNotebook}
+                    onDeleteNotebook={handleDeleteNotebook}
                     topOffset={greetingTopOffset}
                   />
                 </motion.div>

--- a/src/components/layout/RecentNotebooksList.tsx
+++ b/src/components/layout/RecentNotebooksList.tsx
@@ -169,7 +169,15 @@ export function RecentNotebooksList({ notebooks, onSelectNotebook, onDeleteNoteb
                   <div className="flex justify-between text-sm">
                     <div className="flex gap-3">
                       <button className="text-step-11 hover:text-birkin transition-colors">Details</button>
-                      <button className="text-step-11 hover:text-birkin transition-colors">Open</button>
+                      <button 
+                        className="text-step-11 hover:text-birkin transition-colors"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onSelectNotebook(notebook.id);
+                        }}
+                      >
+                        Open
+                      </button>
                     </div>
                     <button 
                       className="text-step-11 hover:text-birkin transition-colors"

--- a/src/components/layout/RecentNotebooksList.tsx
+++ b/src/components/layout/RecentNotebooksList.tsx
@@ -11,6 +11,11 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from '../ui/dropdown-menu';
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '../ui/hover-card';
 
 interface RecentNotebooksListProps {
   notebooks: RecentNotebook[];
@@ -100,21 +105,45 @@ export function RecentNotebooksList({ notebooks, onSelectNotebook, topOffset = 0
               ease: "easeOut"
             }}
           >
-            <Button
-              variant="ghost"
-              className="w-full justify-start text-left h-auto py-2 px-3 hover:bg-step-2/80 dark:hover:bg-step-2/50"
-              style={{ marginLeft: '-12px' }}
-              onClick={() => onSelectNotebook(notebook.id)}
-            >
-              <div className="flex items-center justify-between w-full">
-                <div className="font-medium text-step-11.5 truncate">
-                  {notebook.title}
+            <HoverCard openDelay={700} closeDelay={0}>
+              <HoverCardTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="w-full justify-start text-left h-auto py-2 px-3 hover:bg-step-2 dark:hover:bg-step-2 data-[state=open]:bg-step-2"
+                  style={{ marginLeft: '-12px' }}
+                  onClick={() => onSelectNotebook(notebook.id)}
+                >
+                  <div className="flex items-center justify-between w-full">
+                    <div className="font-medium text-step-11.5 truncate">
+                      {notebook.title}
+                    </div>
+                    <div className="text-step-11 text-muted-foreground whitespace-nowrap ml-2">
+                      {getRelativeTime(notebook.lastAccessed)}
+                    </div>
+                  </div>
+                </Button>
+              </HoverCardTrigger>
+              <HoverCardContent 
+                className="w-80 py-2 px-3 bg-step-2 text-step-11.5 dark:text-step-11 border-0 rounded-tl-none rounded-tr-none shadow-none"
+                align="end"
+                sideOffset={-8}
+              >
+                <div className="space-y-2">
+                  <p className="text-sm">
+                    {/* TODO: Fetch actual summary from JeffersObject using notebook.objectId */}
+                    Beautiful country burn again, Point Pinos down to the
+                    Sur Rivers. Burn as before with bitter wonders, land and ocean and the Carmel water.
+                  </p>
+                  <div className="flex justify-between text-sm">
+                    <div className="flex gap-3">
+                      <button className="text-step-11 hover:text-birkin transition-colors">Details</button>
+                      <button className="text-step-11 hover:text-birkin transition-colors">Open</button>
+                    </div>
+                    <button className="text-step-11 hover:text-birkin transition-colors">Delete</button>
+                  </div>
                 </div>
-                <div className="text-step-11 text-muted-foreground whitespace-nowrap ml-2">
-                  {getRelativeTime(notebook.lastAccessed)}
-                </div>
-              </div>
-            </Button>
+              </HoverCardContent>
+            </HoverCard>
           </motion.div>
         ))}
       </div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -12,7 +12,7 @@ const buttonVariants = cva(
         default:
           "bg-step-11 text-step-1 shadow-xs hover:bg-birkin",
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-tomato-11 text-white shadow-xs hover:bg-tomato-12 focus-visible:ring-tomato-7 dark:bg-tomato-11 dark:hover:bg-tomato-12 dark:focus-visible:ring-tomato-7",
         outline:
           "border bg-step-1 shadow-xs hover:bg-step-2 hover:text-birkin dark:bg-step-6/30 dark:border-step-6 dark:hover:bg-step-6/50",
         secondary:

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-step-12/50",
         className
       )}
       {...props}
@@ -115,7 +115,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-step-10 text-sm", className)}
+      className={cn("text-step-11-5 text-sm", className)}
       {...props}
     />
   )

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -37,6 +37,20 @@ const config: Config = {
           '11.5': 'var(--step-11-5)',
           12: 'var(--step-12)',
         },
+        tomato: {
+          1: 'var(--tomato-1)',
+          2: 'var(--tomato-2)',
+          3: 'var(--tomato-3)',
+          4: 'var(--tomato-4)',
+          5: 'var(--tomato-5)',
+          6: 'var(--tomato-6)',
+          7: 'var(--tomato-7)',
+          8: 'var(--tomato-8)',
+          9: 'var(--tomato-9)',
+          10: 'var(--tomato-10)',
+          11: 'var(--tomato-11)',
+          12: 'var(--tomato-12)',
+        },
         /**
          * @deprecated Semantic color names will be removed in a future
          * release. Use the step palette instead. These aliases are kept for


### PR DESCRIPTION
  Hover Card Implementation
  - Added hover cards to notebook list items that appear after 700ms delay
  - Hover cards display notebook summary (currently placeholder text), along with Details, Open, and Delete action buttons
  - Seamless visual integration with custom positioning and styling

  Notebook Deletion
  - Added Delete button in hover card that triggers a confirmation dialog
  - Integrated with backend via window.api.deleteNotebook()
  - Proper error handling and state management for removed notebooks
  - Parent component callback pattern for updating the notebook list

  Design System Extension
  - Added complete Radix tomato color palette (12 steps) to Tailwind configuration
  - Applied to dialog styling

  Navigation Improvement
  - Connected Open button in hover card to navigate to selected notebook
  - Maintains consistent behavior with clicking the notebook list item
  - Maybe this is too much but I think it's nice to have. Let's keep an eye out for feedback
  
  Not yet implemented:
  - Notebook details page (like an information dense version of expose, or a dashboard for notebooks)
    - titles and summaries of objects and composite objects
    - chat with context
    - manage notebook content
 - Notebook summaries (to be completed alongside compositeobjectenrichmentservice refinement)