### PR TITLE
Notebook overlay z-index

### DIFF
--- a/src/components/NotebookView.tsx
+++ b/src/components/NotebookView.tsx
@@ -921,5 +921,5 @@ export default function NotebookView({ notebookId }: NotebookViewProps) {
     );
   }
 
-  return <NotebookWorkspace notebookId={resolvedNotebookId} />;
+  return <NotebookWorkspace key={resolvedNotebookId} notebookId={resolvedNotebookId} />;
 }

--- a/src/components/NotebookView.tsx
+++ b/src/components/NotebookView.tsx
@@ -216,7 +216,7 @@ function NotebookContent({
       {/* Notebook info pill positioned at top left */}
       {notebookTitle && (
         <motion.div 
-          className="notebook-info-pill-container fixed top-4 left-4"
+          className="notebook-info-pill-container fixed top-1 left-1"
           initial={{ opacity: 0 }}
           animate={{ opacity: isReady ? 1 : 0 }}
           transition={{ duration: 0.4, ease: "easeOut" }}

--- a/src/components/NotebookView.tsx
+++ b/src/components/NotebookView.tsx
@@ -93,11 +93,14 @@ function NotebookContent({
       const isRecentlyRestored = activeWindow.restoredAt && 
         (Date.now() - activeWindow.restoredAt) < 1000;
       
-      if ((isSidebarHovered || isNotebookDropdownOpen) && !isRecentlyRestored) {
-        // Sidebar is hovered OR notebook dropdown is open - freeze the active browser window if it's not already frozen
+      if ((isSidebarHovered || isNotebookDropdownOpen || isIntentLineVisible) && !isRecentlyRestored) {
+        // Sidebar is hovered OR notebook dropdown is open OR intent line is visible - freeze the active browser window if it's not already frozen
         // and it wasn't just restored
         if (currentPayload.freezeState?.type === 'ACTIVE') {
-          console.log(`[NotebookContent] ${isSidebarHovered ? 'Sidebar hovered' : 'Notebook dropdown open'}, freezing active browser window ${activeWindow.id}`);
+          const reason = isSidebarHovered ? 'Sidebar hovered' : 
+                        isNotebookDropdownOpen ? 'Notebook dropdown open' : 
+                        'Intent line visible';
+          console.log(`[NotebookContent] ${reason}, freezing active browser window ${activeWindow.id}`);
           activeStore.getState().updateWindowProps(activeWindow.id, {
             payload: {
               ...currentPayload,
@@ -106,9 +109,10 @@ function NotebookContent({
           });
         }
       } else {
-        // Sidebar is not hovered AND notebook dropdown is closed OR window was recently restored - unfreeze the active browser window if it's frozen
+        // None of the triggers are active OR window was recently restored - unfreeze the active browser window if it's frozen
         if (currentPayload.freezeState?.type !== 'ACTIVE') {
-          console.log(`[NotebookContent] ${!isSidebarHovered && !isNotebookDropdownOpen ? 'Sidebar not hovered and dropdown closed' : 'Window recently restored'}, unfreezing active browser window ${activeWindow.id}`);
+          const reason = isRecentlyRestored ? 'Window recently restored' : 'All triggers inactive';
+          console.log(`[NotebookContent] ${reason}, unfreezing active browser window ${activeWindow.id}`);
           activeStore.getState().updateWindowProps(activeWindow.id, {
             payload: {
               ...currentPayload,
@@ -119,7 +123,7 @@ function NotebookContent({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSidebarHovered, isNotebookDropdownOpen, activeStore]);
+  }, [isSidebarHovered, isNotebookDropdownOpen, isIntentLineVisible, activeStore]);
   
   console.log(`[NotebookContent] Rendering with ${windows.length} windows:`, {
     notebookId,

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -42,7 +42,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-step-1 text-step-12 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          "bg-step-1 text-step-11.5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
           className
         )}
         {...props}
@@ -74,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-step-2 focus:text-step-11 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-step-10 relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-step-3 focus:text-step-12 hover:bg-step-3 hover:text-step-12 text-step-11.5 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-step-11 relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -170,7 +170,7 @@ function DropdownMenuSeparator({
   return (
     <DropdownMenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
-      className={cn("bg-step-6 -mx-1 my-1 h-px", className)}
+      className={cn("bg-step-4 -mx-1 my-1 h-px", className)}
       {...props}
     />
   )

--- a/src/components/ui/notebook-info-pill.tsx
+++ b/src/components/ui/notebook-info-pill.tsx
@@ -19,9 +19,10 @@ interface NotebookInfoPillProps {
   className?: string;
   onTitleChange?: (newTitle: string) => void;
   parentZIndex?: number;
+  onDropdownOpenChange?: (isOpen: boolean) => void;
 }
 
-export function NotebookInfoPill({ title, className = "", onTitleChange, parentZIndex = 5 }: NotebookInfoPillProps) {
+export function NotebookInfoPill({ title, className = "", onTitleChange, parentZIndex = 5, onDropdownOpenChange }: NotebookInfoPillProps) {
   const [currentTime, setCurrentTime] = useState(new Date());
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(title);
@@ -174,7 +175,10 @@ export function NotebookInfoPill({ title, className = "", onTitleChange, parentZ
         '--dropdown-z-index': parentZIndex
       } as React.CSSProperties}
     >
-      <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
+      <DropdownMenu open={isDropdownOpen} onOpenChange={(open) => {
+        setIsDropdownOpen(open);
+        onDropdownOpenChange?.(open);
+      }}>
         <DropdownMenuTrigger asChild>
           <button 
             className="p-0 border-0 bg-transparent hover:bg-transparent focus:outline-none focus-visible:outline-none"

--- a/src/components/ui/notebook-info-pill.tsx
+++ b/src/components/ui/notebook-info-pill.tsx
@@ -168,9 +168,9 @@ export function NotebookInfoPill({ title, className = "", onTitleChange, parentZ
   
   return (
     <div 
-      className={`inline-flex items-center gap-2 px-3 py-1.5 bg-step-2 text-step-11 hover:bg-step-4 hover:text-step-12 hover:shadow-md rounded-md text-sm font-medium cursor-pointer transition-all duration-200 ${isEditing ? 'min-w-fit' : ''} ${className}`} 
+      className={`inline-flex items-center gap-2 px-3 py-1.5 bg-step-2 text-step-11 hover:bg-step-4 hover:text-step-12 hover:shadow-md rounded text-sm font-medium cursor-pointer transition-all duration-200 ${isEditing ? 'min-w-fit' : ''} ${className}`} 
       style={{ 
-        borderRadius: '6px',
+        borderRadius: '4px',
         width: isEditing ? 'auto' : undefined,
         '--dropdown-z-index': parentZIndex
       } as React.CSSProperties}
@@ -189,7 +189,7 @@ export function NotebookInfoPill({ title, className = "", onTitleChange, parentZ
         </DropdownMenuTrigger>
         <DropdownMenuContent 
           align="start" 
-          className="w-64 notebook-dropdown"
+          className="w-64 notebook-dropdown bg-step-1/70 backdrop-blur-md"
           onMouseEnter={() => {
             // Trigger parent hover state when dropdown is open
             const pillContainer = document.querySelector('.notebook-info-pill-container');
@@ -198,10 +198,8 @@ export function NotebookInfoPill({ title, className = "", onTitleChange, parentZ
             }
           }}
         >
-          <DropdownMenuLabel>Recent Notebooks</DropdownMenuLabel>
-          <DropdownMenuSeparator />
           {recentNotebooks.length === 0 ? (
-            <div className="px-2 py-4 text-center text-sm text-muted-foreground">
+            <div className="px-2 py-4 text-center text-sm text-step-11">
               No recent notebooks
             </div>
           ) : (
@@ -212,14 +210,14 @@ export function NotebookInfoPill({ title, className = "", onTitleChange, parentZ
                   key={notebook.id}
                   onClick={() => handleSelectNotebook(notebook.id)}
                   disabled={isCurrentNotebook}
-                  className={isCurrentNotebook ? 'bg-step-2' : ''}
+                  className={isCurrentNotebook ? 'bg-step-3' : ''}
                 >
                   <div className="flex items-center justify-between w-full">
                     <span className="truncate font-medium">
                       {notebook.title}
-                      {isCurrentNotebook && <span className="text-step-9 ml-1 font-normal">(current)</span>}
+                      {isCurrentNotebook && <span className="text-step-11 ml-1 font-normal">(current)</span>}
                     </span>
-                    <span className="text-xs text-muted-foreground ml-2">
+                    <span className="text-xs text-step-11 ml-2">
                       {getRelativeTime(notebook.lastAccessed)}
                     </span>
                   </div>

--- a/src/components/ui/notebook-info-pill.tsx
+++ b/src/components/ui/notebook-info-pill.tsx
@@ -168,7 +168,7 @@ export function NotebookInfoPill({ title, className = "", onTitleChange, parentZ
   
   return (
     <div 
-      className={`inline-flex items-center gap-2 px-3 py-1.5 bg-step-2 text-step-11 hover:bg-step-4 hover:text-step-12 hover:shadow-md rounded text-sm font-medium cursor-pointer transition-all duration-200 ${isEditing ? 'min-w-fit' : ''} ${className}`} 
+      className={`inline-flex items-center gap-2 px-3 py-1.5 bg-step-2 text-step-11 hover:bg-step-3 hover:text-step-12 hover:shadow-sm rounded text-sm font-medium cursor-pointer transition-all duration-200 ${isEditing ? 'min-w-fit' : ''} ${className}`} 
       style={{ 
         borderRadius: '4px',
         width: isEditing ? 'auto' : undefined,

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -46,13 +46,13 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-step-11 text-step-1 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          "bg-step-1/70 backdrop-blur-md text-step-11.5 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[1050] w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
           className
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-step-11 fill-step-11 z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow className="bg-step-1/70 fill-step-1/70 z-[1050] size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )


### PR DESCRIPTION
  Browser Freeze State Management

  - Applied comprehensive browser window freezing when users interact with UI overlays to address Electron's Z-index situation
  - Browser windows now freeze (capture screenshot) when ANY of these conditions are met:
    - Sidebar is hovered
    - Notebook dropdown menu is open
    - Intent line is visible/active
  - Added 1-second grace period for recently restored windows to prevent jarring freeze/unfreeze cycles
  - Improved logging to clearly indicate which trigger caused the freeze

  UI Component Improvements

  - Tooltips: Increased z-index to 1050 and applied glassmorphism effect (70% opacity with backdrop blur)
  - Dropdown menus: Refined styling with consistent text colors and glassmorphism
  - NotebookInfoPill:
    - Moved position from top-4/left-4 to top-1/left-1 for better visual alignment
    - Added dropdown state tracking to trigger browser freeze
    - Simplified dropdown design by removing redundant label

  Bug Fixes

  - Fixed notebook switching issue by adding key prop to NotebookWorkspace component to force proper remount

  Technical Details

  The browser freeze mechanism makes it possible for react content to layer on top of electron webcontentsviews when:
  - Reviewing open tabs/objects in the sidebar
  - Switching between notebooks via the dropdown
  - Using the intent line for commands