### PR TITLE
fix: prevent note editor content reset by generating noteId upfront

### DIFF
--- a/electron/ipc/createNote.ts
+++ b/electron/ipc/createNote.ts
@@ -16,7 +16,8 @@ export function registerCreateNoteHandler(
         payload.notebookId,
         payload.content,
         payload.type || 'text',
-        payload.metadata
+        payload.metadata,
+        payload.id
       );
       
       return note;

--- a/models/NoteModel.ts
+++ b/models/NoteModel.ts
@@ -41,13 +41,14 @@ export class NoteModel {
    * Creates a new note in the database.
    */
   create(params: {
+    id?: string;
     notebookId: string;
     content: string;
     type?: NoteType;
     metadata?: NoteMetadata | null;
     position?: number;
   }): Note {
-    const id = uuidv4();
+    const id = params.id || uuidv4();
     const now = new Date().toISOString();
     
     // If position is not provided, get the next position

--- a/services/NoteService.ts
+++ b/services/NoteService.ts
@@ -21,10 +21,12 @@ export class NoteService extends BaseService<NoteServiceDeps> {
     notebookId: string,
     content: string,
     type: NoteType = 'text',
-    metadata?: NoteMetadata
+    metadata?: NoteMetadata,
+    id?: string
   ): Promise<Note> {
     return this.execute('createNote', async () => {
       const note = this.deps.noteModel.create({
+        id,
         notebookId,
         content,
         type,

--- a/shared/types/notes.types.ts
+++ b/shared/types/notes.types.ts
@@ -22,6 +22,7 @@ export interface Note {
 
 /** Payload for creating a note. */
 export interface CreateNotePayload {
+  id?: string;
   notebookId: string;
   content: string;
   type?: NoteType;

--- a/shared/types/window.types.ts
+++ b/shared/types/window.types.ts
@@ -39,7 +39,7 @@ export interface NotebookRawEditorPayload extends BaseWindowPayload {
 
 /** Payload for a note editor window. */
 export interface NoteEditorPayload extends BaseWindowPayload {
-  noteId?: string; // Optional: ID of existing note to edit
+  noteId: string; // Required: ID of the note to edit
   notebookId: string; // Required: ID of the notebook this note belongs to
 }
 

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Home, MessageSquare, Globe, MonitorIcon, FileText, LucideIcon } from "lucide-react";
+import { v4 as uuidv4 } from 'uuid';
 import { NoteEditorPayload, WindowContentType } from "../../shared/types";
 import { VerticalTabs } from "@/components/VerticalTabs";
 import {
@@ -50,6 +51,7 @@ export function AppSidebar({ onAddChat, onAddBrowser, onGoHome, windows = [], ac
     if (!activeStore || !notebookId) return;
     
     const payload: NoteEditorPayload = {
+      noteId: uuidv4(),
       notebookId,
     };
     

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Home, MessageSquare, Globe, MonitorIcon, FileText, LucideIcon } from "lucide-react";
-import { v4 as uuidv4 } from 'uuid';
 import { NoteEditorPayload, WindowContentType } from "../../shared/types";
 import { VerticalTabs } from "@/components/VerticalTabs";
 import {
@@ -47,23 +46,34 @@ interface AppSidebarProps {
 export function AppSidebar({ onAddChat, onAddBrowser, onGoHome, windows = [], activeStore, notebookId }: AppSidebarProps) {
   const minimizedWindows = windows.filter(w => w.isMinimized);
   
-  const handleNewNote = () => {
+  const handleNewNote = async () => {
     if (!activeStore || !notebookId) return;
     
-    const payload: NoteEditorPayload = {
-      noteId: uuidv4(),
-      notebookId,
-    };
-    
-    activeStore.getState().addWindow({
-      type: 'note_editor' as WindowContentType,
-      payload,
-      preferredMeta: {
-        title: 'New Note',
-        width: 600,
-        height: 400,
-      }
-    });
+    try {
+      // Create the note via service and get the ID
+      const note = await window.api.createNote({
+        notebookId,
+        content: "",
+        type: 'text'
+      });
+      
+      const payload: NoteEditorPayload = {
+        noteId: note.id,
+        notebookId,
+      };
+      
+      activeStore.getState().addWindow({
+        type: 'note_editor' as WindowContentType,
+        payload,
+        preferredMeta: {
+          title: 'New Note',
+          width: 600,
+          height: 400,
+        }
+      });
+    } catch (error) {
+      console.error('[AppSidebar] Failed to create new note window:', error);
+    }
   };
   
   


### PR DESCRIPTION
Generate UUID for new notes when creating note editor windows instead of during editing. 


https://github.com/user-attachments/assets/170b5623-03ce-4f4e-8cd4-61d68d1ca942

-[ ] Gotta see into other rendering issues